### PR TITLE
luci-app-turboacc:SFE and FLOW switching is enabled by default

### DIFF
--- a/applications/luci-app-turboacc/Makefile
+++ b/applications/luci-app-turboacc/Makefile
@@ -38,8 +38,8 @@ config PACKAGE_$(PKG_NAME)_INCLUDE_OFFLOADING
 
 config PACKAGE_$(PKG_NAME)_INCLUDE_SHORTCUT_FE
 	bool "Include Shortcut-FE"
-	depends on PACKAGE_$(PKG_NAME)_INCLUDE_OFFLOADING=n
-	default n
+	#depends on PACKAGE_$(PKG_NAME)_INCLUDE_OFFLOADING=n
+	default y
 
 config PACKAGE_$(PKG_NAME)_INCLUDE_SHORTCUT_FE_CM
 	bool "Include Shortcut-FE CM"

--- a/applications/luci-app-turboacc/root/etc/config/turboacc
+++ b/applications/luci-app-turboacc/root/etc/config/turboacc
@@ -1,7 +1,7 @@
 
 config turboacc 'config'
-	option sw_flow '1'
-	option hw_flow '1'
+	option sw_flow '0'
+	option hw_flow '0'
 	option sfe_flow '1'
 	option fullcone_nat '1'
 	option bbr_cca '0'


### PR DESCRIPTION
Turboacc supports both Flow Offload and Shortcut-FE But only one can be enabled at a time
A reboot is recommended if you switch from one to the other.